### PR TITLE
[Bug Fix] Fix Premature Game Ending

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -42,16 +42,16 @@ const Board = ({ context, gamesCount, onGameOver }) => {
     return rows;
   };
 
-  const handleMove = (originatedPosition, moveDirection, onSuccessfulMove) => {
+  const handleMove = (originPosition, moveDirection, onSuccessfulMove) => {
     const validSpaceCollidingWith = validCollisionOnSwipe(
-      originatedPosition,
+      originPosition,
       moveDirection,
       gamePieces
     );
 
     if (validSpaceCollidingWith !== undefined) {
       handleCollision(
-        originatedPosition,
+        originPosition,
         validSpaceCollidingWith,
         onSuccessfulMove
       );
@@ -116,9 +116,13 @@ const Board = ({ context, gamesCount, onGameOver }) => {
       gamePiecesFromState[vacatedPosition].swell = true;
       setGamePiecesData(gamePiecesFromState);
 
-      if (noValidMovesAvailable()) {
+      if (
+        BoardHelpers.noSpacesAreEmpty(gamePieces) &&
+        noValidMovesAvailable()
+      ) {
         onGameOver();
       }
+
       return;
     }
 
@@ -129,7 +133,6 @@ const Board = ({ context, gamesCount, onGameOver }) => {
 
   const onCollisionComplete = position => {
     const gamePiecesFromState = { ...gamePieces };
-    gamePiecesFromState[position].color = null;
     gamePiecesFromState[position].colorWhileAnimating = null;
     gamePiecesFromState[position].isAnimating = false;
     setGamePiecesData(gamePiecesFromState);
@@ -148,9 +151,6 @@ const Board = ({ context, gamesCount, onGameOver }) => {
     setGamePiecesData(gamePiecesFromState);
 
     fillSpacesDown(position);
-    if (noValidMovesAvailable()) {
-      onGameOver();
-    }
   };
 
   return (
@@ -189,7 +189,6 @@ const Board = ({ context, gamesCount, onGameOver }) => {
                       key={`${i}-${j}`}
                       data={gamePieces[position]}
                       boardWidth={boardWidth}
-                      onValidCollision={handleCollision}
                       onMove={handleMove}
                       onCollisionComplete={onCollisionComplete}
                       onShiftComplete={onShiftComplete}

--- a/components/Board.js
+++ b/components/Board.js
@@ -127,13 +127,6 @@ const Board = ({ context, gamesCount, onGameOver }) => {
     setGamePiecesData(gamePiecesFromState);
   };
 
-  const onSwellComplete = position => {
-    const gamePiecesFromState = { ...gamePieces };
-
-    gamePiecesFromState[position].swell = false;
-    setGamePiecesData(gamePiecesFromState);
-  };
-
   const onCollisionComplete = position => {
     const gamePiecesFromState = { ...gamePieces };
     gamePiecesFromState[position].color = null;
@@ -200,7 +193,6 @@ const Board = ({ context, gamesCount, onGameOver }) => {
                       onMove={handleMove}
                       onCollisionComplete={onCollisionComplete}
                       onShiftComplete={onShiftComplete}
-                      onSwellComplete={onSwellComplete}
                     />
                   );
                 } else {

--- a/components/Dot.js
+++ b/components/Dot.js
@@ -15,7 +15,6 @@ const Dot = ({
   verticalShift,
   onAnimationComplete,
   isShifting,
-  onSwellComplete,
   showSwell,
 }) => {
   const defaultDotSize =

--- a/components/GameDot.js
+++ b/components/GameDot.js
@@ -13,7 +13,6 @@ const GameDot = ({
   boardWidth,
   onMove,
   onCollisionComplete,
-  onValidCollision,
   data,
   onShiftComplete,
 }) => {

--- a/components/GameDot.js
+++ b/components/GameDot.js
@@ -16,7 +16,6 @@ const GameDot = ({
   onValidCollision,
   data,
   onShiftComplete,
-  onSwellComplete,
 }) => {
   const [dotColor, setDotColor] = useState(null);
   const [horizontalShift, setHorizontalShift] = useState(0);
@@ -78,7 +77,6 @@ const GameDot = ({
             shift ? onShiftComplete(position) : onCollisionComplete(position)
           }
           isShifting={shift}
-          onSwellComplete={() => onSwellComplete(position)}
           showSwell={!!swell}
         />
       </View>

--- a/helpers/__tests__/boardHelpers.test.js
+++ b/helpers/__tests__/boardHelpers.test.js
@@ -134,3 +134,21 @@ describe('pieceHasValidMove', () => {
     expect(actual).toEqual(true);
   });
 });
+
+describe('noSpacesAreEmpty', () => {
+  it('returns true if no board spaces are empty', () => {
+    const actual = BoardHelpers.noSpacesAreEmpty(
+      TestSetupHelpers.boardWithNoValidMoves
+    );
+
+    expect(actual).toEqual(true);
+  });
+
+  it('returns false if at least one board space is empty', () => {
+    const actual = BoardHelpers.noSpacesAreEmpty(
+      TestSetupHelpers.boardWithEmptySpace
+    );
+
+    expect(actual).toEqual(false);
+  });
+});

--- a/helpers/boardHelpers.js
+++ b/helpers/boardHelpers.js
@@ -80,3 +80,6 @@ export const pieceHasValidMove = (piece, board) => {
     return adjacentPieces.some(p => pieceIsBlack(p));
   }
 };
+
+export const noSpacesAreEmpty = pieces =>
+  !Object.values(pieces).some(piece => piece.color === null);

--- a/helpers/testSetupHelpers.js
+++ b/helpers/testSetupHelpers.js
@@ -75,3 +75,42 @@ export const boardWithValidMoves = {
     color: 'black',
   },
 };
+
+export const boardWithEmptySpace = {
+  0: {
+    position: 0,
+    color: 'red',
+  },
+  1: {
+    position: 1,
+    color: 'red',
+  },
+  2: {
+    position: 2,
+    color: null,
+  },
+  3: {
+    position: 3,
+    color: 'purple',
+  },
+  4: {
+    position: 4,
+    color: 'purple',
+  },
+  5: {
+    position: 5,
+    color: 'purple',
+  },
+  6: {
+    position: 6,
+    color: 'black',
+  },
+  7: {
+    position: 7,
+    color: 'black',
+  },
+  8: {
+    position: 8,
+    color: 'black',
+  },
+};

--- a/screens/GameScreen.js
+++ b/screens/GameScreen.js
@@ -8,6 +8,7 @@ import HelpModal from '../components/HelpModal';
 import GameOverModal from '../components/GameOverModal';
 import PauseModal from '../components/PauseModal';
 import { BANNER_AD_UNIT_ID } from '../util/adConfigs';
+import { SMALLER_THAN_IPAD_SCREEN_WIDTH } from '../util/configs';
 
 const GameScreen = props => {
   const context = props.screenProps.context;
@@ -84,7 +85,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     width: '100%',
     paddingHorizontal: '5%',
-    paddingTop: '15%', // 10% if iPad
+    paddingTop: SMALLER_THAN_IPAD_SCREEN_WIDTH ? '15%' : '10%',
   },
 });
 

--- a/util/configs.js
+++ b/util/configs.js
@@ -7,3 +7,6 @@ export const DOT_ACTION_DURATION = 150;
 export const GET_DOT_WIDTH = boardWidth =>
   (boardWidth - GAME_BOARD_SPACING * (GAME_BOARD_DIMENSION + 1)) /
   GAME_BOARD_DIMENSION;
+
+export const SMALLER_THAN_IPAD_SCREEN_WIDTH =
+  Dimensions.get('window').width < 768;


### PR DESCRIPTION
- Remove unused `onSwellComplete`
- Prevent game from checking for game over state while some spaces are still empty / in the process of being filled